### PR TITLE
Add possible workaround for "any" type issues

### DIFF
--- a/src/main/openapi/problem/v1/problem-v1.yaml
+++ b/src/main/openapi/problem/v1/problem-v1.yaml
@@ -84,7 +84,14 @@ components:
           type: string
         value:
           description: The value of the erroneous parameter
-          # no type specified, allowing any type. This is valid OpenAPI 3.0 even though some editors may indicate an error (issue #25)
+          # Define all possible types as default "type: object" can cause issues in some editors/validation libraries
+          oneOf:
+            - type: string
+            - type: number
+            - type: integer
+            - type: boolean
+            - type: array
+            - type: object
     InputValidationProblem:
       type: object
       allOf:
@@ -145,4 +152,12 @@ components:
             - query
         name:
           type: string
-        value: {} # any type allowed
+        value:
+          # Define all possible types as default "type: object" can cause issues in some editors/validation libraries
+          oneOf:
+            - type: string
+            - type: number
+            - type: integer
+            - type: boolean
+            - type: array
+            - type: object


### PR DESCRIPTION
Certain notation types to indicate a property can have "any" value cause issues in editors or validation libraries. This PR adds a possible workaround for it by explicitly defining all possible types using a "oneOf" notation.